### PR TITLE
Add reports and participation analytics

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -130,3 +130,24 @@ def unregister_from_activity(activity_name: str, email: str):
     # Remove student
     activity["participants"].remove(email)
     return {"message": f"Unregistered {email} from {activity_name}"}
+
+
+@app.get("/reports/summary")
+def get_reports_summary():
+    """Get participation analytics summary for all activities"""
+    summary = []
+    for name, details in activities.items():
+        enrolled = len(details["participants"])
+        max_p = details["max_participants"]
+        spots_remaining = max_p - enrolled
+        fill_rate = round((enrolled / max_p) * 100, 1) if max_p > 0 else 0.0
+        summary.append({
+            "activity": name,
+            "total_enrolled": enrolled,
+            "max_participants": max_p,
+            "spots_remaining": spots_remaining,
+            "fill_rate": fill_rate
+        })
+    # Sort by total enrolled descending (most popular first)
+    summary.sort(key=lambda x: x["total_enrolled"], reverse=True)
+    return {"summary": summary}

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -155,6 +155,34 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   });
 
+  // Handle Reports section
+  const loadReportsBtn = document.getElementById("load-reports-btn");
+  const reportsContent = document.getElementById("reports-content");
+  const reportsTbody = document.getElementById("reports-tbody");
+
+  loadReportsBtn.addEventListener("click", async () => {
+    try {
+      const response = await fetch("/reports/summary");
+      const data = await response.json();
+
+      reportsTbody.innerHTML = "";
+      data.summary.forEach((row) => {
+        const tr = document.createElement("tr");
+        tr.innerHTML = `
+          <td>${row.activity}</td>
+          <td>${row.total_enrolled}</td>
+          <td>${row.spots_remaining}</td>
+          <td>${row.fill_rate}%</td>
+        `;
+        reportsTbody.appendChild(tr);
+      });
+
+      reportsContent.classList.remove("hidden");
+    } catch (error) {
+      console.error("Error loading reports:", error);
+    }
+  });
+
   // Initialize app
   fetchActivities();
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -21,6 +21,25 @@
         </div>
       </section>
 
+      <section id="reports-container">
+        <h3>Participation Reports</h3>
+        <button id="load-reports-btn">Load Reports</button>
+        <div id="reports-content" class="hidden">
+          <table id="reports-table">
+            <thead>
+              <tr>
+                <th>Activity</th>
+                <th>Total Enrolled</th>
+                <th>Spots Remaining</th>
+                <th>Fill Rate</th>
+              </tr>
+            </thead>
+            <tbody id="reports-tbody">
+            </tbody>
+          </table>
+        </div>
+      </section>
+
       <section id="signup-container">
         <h3>Sign Up for an Activity</h3>
         <form id="signup-form">


### PR DESCRIPTION
Closes #13

## Changes

### Backend
- Added `GET /reports/summary` endpoint to `app.py` that returns enrollment statistics for all activities, sorted by popularity (most enrolled first)
- Each entry includes: activity name, total enrolled, max participants, spots remaining, and fill rate (%)

### Frontend
- Added a **Reports** section to `index.html` with a "Load Reports" button and a data table (Activity, Total Enrolled, Spots Remaining, Fill Rate)
- Added JS logic in `app.js` to fetch `/reports/summary` and populate the table on demand

## Acceptance Criteria
- [x] Reports endpoint returns enrollment stats per activity
- [x] Admin dashboard has a Reports section/view
- [x] Reports show: activity name, total enrolled, spots remaining, and fill rate
- [x] Data is accurate and reflects current enrollment state